### PR TITLE
Fix package dependencies

### DIFF
--- a/lib/commands/bridge/index.js
+++ b/lib/commands/bridge/index.js
@@ -5,7 +5,7 @@ var json = require('../../json');
 var serialWatcher = require('watch-serial');
 var cp = require('child_process');
 var split = require('binary-split');
-var shuffle = require('shuffle-array');
+var shuffle = require('array-shuffle');
 var pingid = 0;
 
 try{

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "url": "https://github.com/Pinoccio/client-node-pinoccio/issues"
   },
   "dependencies": {
+    "array-shuffle": "1.0.0",
     "backoff": "~2.3.0",
     "binary-split": "~0.1.1",
     "buffer-indexof": "~0.0.1",
@@ -51,7 +52,6 @@
     "rpc-stream": "~1.0.5",
     "serialport": "~1.5.0",
     "shoe": "~0.0.15",
-    "shuffle-array": "0.0.2",
     "split": "~0.2.10",
     "stk500-v2": "~1.0.0",
     "through": "~2.3.4",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "array-shuffle": "1.0.0",
     "backoff": "~2.3.0",
     "binary-split": "~0.1.1",
+    "browserify": "~4.0.0",
     "buffer-indexof": "~0.0.1",
     "colors": "~0.6.2",
     "concat-stream": "~1.2.1",
@@ -63,7 +64,6 @@
   },
   "devDependencies": {
     "tape": "~2.3.2",
-    "browserify": "~3.18.0",
     "reconnect-core": "~0.0.1"
   }
 }

--- a/test/rpcerrorstream.js
+++ b/test/rpcerrorstream.js
@@ -63,9 +63,9 @@ test("can connect",function(t){
     });
 
     stop = true;
-    setImmediate(function(){
+    setTimeout(function(){
       _con.destroy();
-    });
+    }, 500);
   });
 });
 


### PR DESCRIPTION
The recent rash of packages being unpublished from npm has caused npm install to fail due to reliance on these no-longer-available dependencies.

This PR replaces the broken dependencies with new packages (or more recent packages) so that this package can continue to be installed.

It's worth noting that all the api rest tests seem to be broken, but (to the best of my knowledge) this seems to be a problem with the tests (or the api end point) and not with the code itself.